### PR TITLE
Document `namespaceSplitter`, and shorten option descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ var messages = {
 };
 
 var options = {
-    debug: true, //[Boolean]: Logs missing translations to console. Defaults to false.
+    // These are the defaults:
+    debug: false,  //[Boolean]: Logs missing translations to console if true`.
+    namespaceSplitter: '::',  // [String|RegExp]: Customizes the translationKey namespace splitter.
 };
 
 var t = translate(messages, [options]);

--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@
  * }
  * 
  * var options = {
- *   debug: true, //[Boolean]: Logs missing translations to console. Defaults to false.
- *   namespaceSplitter: '::' //[String|RegExp]: You can customize the part which splits namespace and translationKeys. Defaults to '::'.
+ *   // These are the defaults:
+ *   debug: false, //[Boolean]: Logs missing translations to console if `true`.
+ *   namespaceSplitter: '::', //[String|RegExp]: Customizes the translationKey namespace splitter.
  * }
  * 
  * var t = libTranslate.getTranslationFunction(messages, [options])


### PR DESCRIPTION
Made these changes while adding the custom `pluralize` option (See #1) - and decided to PR them separately.