### PR TITLE
Add pluralization functions for Icelandic and English

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,5 @@ Translate.js comes with a predefined `pluralize` functions for [several language
 var pluralize_IS = require('translate.js/pluralize/is');
 var t = translate( messages_IS, { pluralize:pluralize_IS  });
 ```
+
+Here's a large list of [pluralization algorithms by language](http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html?id=l10n/pluralforms).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var messages = {
 
 var options = {
     debug: true, //[Boolean]: Logs missing translations to console. Defaults to false.
-    pluralize: function(n,translKey){ return n; }  //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
+    pluralize: function(n,translKey){ return Math.abs(n); }  //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
 };
 
 var t = translate(messages, [options]);
@@ -129,4 +129,11 @@ t('sheep', 0) => 'Engar kindur'
 t('sheep', 1) => '1 kind'
 t('sheep', 2) => '2 kindur'
 t('sheep', 21) => '21 kind'
+```
+
+Translate.js comes with a predefined `pluralize` functions for [several languages](pluralize/). These can be required into your code as needed, like so:
+
+```js
+var pluralize_IS = require('translate.js/pluralize/is');
+var t = translate( messages_IS, { pluralize:pluralize_IS  });
 ```

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * var options = {
  *   debug: true, //[Boolean]: Logs missing translations to console. Defaults to false.
  *   namespaceSplitter: '::' //[String|RegExp]: You can customize the part which splits namespace and translationKeys. Defaults to '::'.
- *   pluralize: function(n,translKey){ return n; } //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
+ *   pluralize: function(n,translKey){ return Math.abs(n); } //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
  * }
  *
  * var t = libTranslate.getTranslationFunction(messages, [options])
@@ -76,7 +76,7 @@ module.exports = function(messageObject, options) {
       }
       var mappedCount = options.pluralize ?
                             options.pluralize( count, translation ):
-                            count;
+                            Math.abs(count);
       if(translation[mappedCount]){
         translation = translation[mappedCount];
       } else if(translation.n) {

--- a/pluralize/en.js
+++ b/pluralize/en.js
@@ -1,0 +1,4 @@
+// English rules: Only 1 is singular
+module.exports = function ( n/*, tarnslationKey*/ ) {
+  return Math.abs(n);
+};

--- a/pluralize/is.js
+++ b/pluralize/is.js
@@ -1,0 +1,4 @@
+// Icelandic rules: Numbers ending in 1 are singular - unless ending in 11.
+module.exports = function ( n/*, tarnslationKey*/ ) {
+  return n===0 ? 0 : (n%10 !== 1 || n%100 === 11) ? 2 : 1;
+};


### PR DESCRIPTION
These can be loaded as needed via
`required('translate.js/pluralize/[LANGUAGE_CODE]')`