### PR TITLE
Expose `messageObject` and options as `.keys` and `.opts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ t.keys.foo = { bar:'baz' }
 t('foo/bar'); => 'baz'
 ```
 
+Immutability can be achieved with a simple wrapper:
+
+```js
+var t2 = function () { return t.apply(null,arguments); };
+```
+
 
 ### Custom pluralization
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,28 @@ t('hits', 99) => '99 Hits'
 
 //combined count and placeholders
 t('date', 2, {day: '13', year: 2014}) => '13. February 2014'
-
 ```
+
+It is flexible, so you can add/replace translations after the fact by modifying the `.keys` property, like so:
+
+```js
+t.keys['add-key'] = 'Sorry I am late!';
+t('add-key'); => 'Sorry I am late!'
+
+t.keys = { 'new-key': 'All is new!' };
+t('new-key'); => 'All is new!'
+t('add-key'); => 'add-key' (No longer translated)
+t('like') => 'like'        (No longer translated)
+```
+
+The translation options can similarily be changed or replaced via the `.opts` property.
+
+```js
+t.opts.namespaceSplitter = '/';
+t.keys.foo = { bar:'baz' }
+t('foo/bar'); => 'baz'
+```
+
 
 ### Custom pluralization
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@
  * @licence May be freely distributed under the MIT license.
  */
 
+/* global console, module */
+
 'use strict';
 
 var isObject = function(obj) {
@@ -40,19 +42,16 @@ var isObject = function(obj) {
 
 
 module.exports = function(messageObject, options) {
-  options = isObject(options) ? options : {};
-
-  var debug = options.debug;
-  var namespaceSplitter = options.namespaceSplitter || '::';
+  var debug = options && options.debug;
 
   function getTranslationValue(translationKey) {
-    var transValue = messageObject[translationKey];
+    var transValue = tFunc.keys[translationKey];
     if( transValue == null ) {
-      var path = translationKey.split( namespaceSplitter );
+      var path = translationKey.split( tFunc.opts && tFunc.opts.namespaceSplitter || '::' );
       if ( path.length > 1 ) {
         var i = 0;
         var len = path.length;
-        transValue = messageObject;
+        transValue = tFunc.keys;
         while ( len > i ) {
           transValue = transValue[ path[i++]||'' ];
           if ( transValue == null ) {
@@ -73,7 +72,8 @@ module.exports = function(messageObject, options) {
     if(translation[mappedCount] != null){
       translation = translation[mappedCount];
     } else {
-      mappedCount = options.pluralize ? options.pluralize( mappedCount, translation ) : mappedCount;
+      var plFunc = (tFunc.opts||{}).pluralize;
+      mappedCount = plFunc ? plFunc( mappedCount, translation ) : mappedCount;
       if(translation[mappedCount] != null){
         translation = translation[mappedCount];
       } else if(translation.n != null) {
@@ -100,7 +100,7 @@ module.exports = function(messageObject, options) {
     });
   }
 
-  return function (translationKey, count, replacements) {
+  var tFunc = function (translationKey, count, replacements) {
     if ( isObject(count) ) {
       var tmp = replacements;
       replacements = count;
@@ -129,4 +129,10 @@ module.exports = function(messageObject, options) {
 
     return translation;
   };
+
+  tFunc.keys = messageObject || {};
+  tFunc.opts = options || {};
+
+
+  return tFunc;
 };

--- a/test.js
+++ b/test.js
@@ -277,6 +277,70 @@ describe('translate.js', function() {
   });
 
 
+
+  var tXKeys = {
+    name: 'English',
+    ns: {
+      x: {
+        13: 'Thirteen',
+        99: 'Ninety-nine',
+        n:  'Default'
+      }
+    }
+  };
+  var tX;
+
+  it('should gracefully handle no parameters', function () {
+    tX= translate();
+    expect( tX('name') ).to.equal( 'name' );
+    expect( tX('ns::x',1) ).to.equal( 'ns::x' );
+  });
+
+  it('should gracefully handle nully (not falsey) parameters', function () {
+    tX = translate(undefined, null);
+    expect( tX('name') ).to.equal( 'name' );
+    expect( tX('ns::x',1) ).to.equal( 'ns::x' );
+  });
+
+  it('should expose .keys and .opts properties', function () {
+    expect( tX.keys ).to.be.an( 'object' );
+    expect( tX.opts ).to.be.an( 'object' );
+    expect( tX.keys ).to.eql( {} );
+  });
+
+  it('should allow late binding of translation keys', function () {
+    tX.keys.foo = 'bar';
+    expect( tX('foo') ).to.equal( 'bar' );
+  });
+
+  it('should allow late binding of translation keys', function () {
+    tX.keys = tXKeys;
+    expect( tX('foo') ).to.equal( 'foo' );
+    expect( tX('name') ).to.equal( 'English' );
+    expect( tX('ns::x',1) ).to.equal( 'Default' );
+  });
+
+  it('should allow late binding of pluralization', function () {
+    tX.opts.pluralize = function (n) { return 99; };
+    expect( tX('ns::x',1) ).to.equal( 'Ninety-nine' );
+  });
+
+  it('should allow late binding of namespaceSplitter', function () {
+    tX.opts.namespaceSplitter = '__';
+    expect( tX('ns__x',1) ).to.equal( 'Ninety-nine' );
+  });
+
+  it('should gracefully handle completely overloading the opts', function () {
+    tX.opts = { pluralize: function (n) { return 13; } };
+    expect( tX('ns::x',1) ).to.equal( 'Thirteen' );
+  });
+
+  it('should gracefully handle accidental removal of opts', function () {
+    delete tX.opts; // Oops!
+    expect( tX('ns::x',1) ).to.equal( 'Default' ); // no pluralization found
+  });
+
+
   // it('should return ', function() {
   //  expect(t()).to.equal();
   // });


### PR DESCRIPTION
This allows for more flexible/light-weight handling of
translation functions, such as:

* Adding more translations incrementally
* Changing locales/languages on the fly
* etc...