### PR TITLE
Add tests and docs for placeholders in an Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ First create a language specific object for your translations:
 var messages = {
     like: 'I like this.',
     likeThing: 'I like {thing}!',
+    like01: 'I like {0} and {1}!',
     simpleCounter: 'The count is {n}.',
     hits: {
         0: 'No Hits',
@@ -96,8 +97,10 @@ t('Prosa Key') => 'This is prosa!'
 //namespace support
 t('namespaceA::like') => 'I like this namespace.'
 
-//palceholders
+//palceholders - named
 t('likeThing', {thing: 'the Sun'}) => 'I like the Sun!'
+//palceholders - array
+t('like01', ['Alice', 'Bob']) => 'I like Alice and Bob!'
 
 //count
 t('simpleCounter', 25) => 'The count is 25'

--- a/test.js
+++ b/test.js
@@ -297,6 +297,28 @@ describe("translate.js", function() {
 		expect(t5('namespaceA::nonexistentkey')).to.equal('@@namespaceA::nonexistentkey@@');
 	});
 
+
+	var t6Keys = {
+		fruit: '{0} apples, {1} oranges, {2} kiwis',
+		bread: '{0} buns, {n} scones',
+		items: {
+			1: '{0} item ({n})',
+			n: '{0} items ({n})'
+		}
+	};
+	var t6 = translate( t6Keys );
+	it('should accept placeholder values in arrays', function () {
+		expect( t6('fruit', ['shiny', 'round']) ).to.equal( 'shiny apples, round oranges, {2} kiwis' );
+	});
+	it('should mix count and array placeholders', function () {
+		expect( t6('bread', 7, [10]) ).to.equal( '10 buns, 7 scones' );
+		expect( t6('bread', [7], 10) ).to.equal( '7 buns, 10 scones' );
+	});
+	it('should mix array placeholders and pluralization', function () {
+		expect( t6('items', 1, ['Happy']) ).to.equal( 'Happy item (1)' );
+		expect( t6('items', 7, ['Funny']) ).to.equal( 'Funny items (7)' );
+	});
+
 	// it("should return ", function() {
 	// 	expect(t()).to.equal();
 	// });


### PR DESCRIPTION
The library already supports numbered placeholders.

This is a useful, lightweight feature (a bit similar to `console.log(' %s %s ', 'foo', 'bar')`) and deserves a test to make sure it's not accidentally removed.