### PR TITLE
Feature: `array` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ var messages = {
 
 var options = {
     // These are the defaults:
-    debug: false, //[Boolean]: Logs missing translations to console and add "@@" around output if `true`.
+    debug: false,  //[Boolean]: Logs missing translations to console and add "@@" around output, if `true`.
+    array: false,  //[Boolean]: Returns translations with placeholder-replacements as Arrays, if `true`.
     pluralize: function(n,translKey){ return Math.abs(n); }  //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
 }
 
@@ -171,16 +172,26 @@ by using the `arr`-helper. It does not convert the translation result to a
 string but rather returns an array with all the placeholder-replacements left intact.
 
 ```js
-  var t = translate({
-    test: 'abc {fancyImage} def'
-  })
+var keys = { test: 'abc {fancyImage} def' }
+var t = translate(keys)
 
-  t.arr('test', {
-    fancyImage: m('img', { src: 'image.jpg' })
-  })
-  // results in ['abc ', { tag: 'img', ... }, ' def']
+t.arr('test', {
+  fancyImage: m('img', { src: 'image.jpg' })
 })
+// results in ['abc ', { tag: 'img', ... }, ' def']
 ```
+
+You can also set this as the default behaviour, by supplying `array:true` option when initializing the translation function.
+
+```js
+ t = translate(keys, { array: true });
+
+t('test', {
+  fancyImage: m('img', { src: 'image.jpg' })
+})
+// results in ['abc ', { tag: 'img', ... }, ' def']
+```
+
 
 ## Namespace-Support
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@
   }
 
   function assemble (parts, replacements, count, debug, asArray) {
-    var result = asArray ? [parts[0]] : parts[0]
+    var result = asArray ? parts.slice() : parts[0]
     var len = parts.length
     for (var i = 1; i < len; i += 2) {
       var part = parts[i]
@@ -55,7 +55,6 @@
       }
       if ( asArray ) {
         result[i] = val
-        result[i+1] = parts[i+1]
       } else {
         result += val + parts[i+1]
       }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@
  *
  * var options = {
  *   // These are the defaults:
- *   debug: false, //[Boolean]: Logs missing translations to console and add "@@" around output if `true`.
+ *   debug: false,  //[Boolean]: Logs missing translations to console and add "@@" around output if `true`.
+ *   array: false,  //[Boolean]: `true` returns translations with placeholder-replacements as Arrays.
  *   pluralize: function(n,translKey){ return Math.abs(n); } //[Function(count,translationKey)]: Provides a custom pluralization mapping function.
  * }
  *
@@ -38,7 +39,7 @@
     return obj && typeof obj === 'object'
   }
 
-  function assemble (parts, replacements, count, debug) {
+  function assemble (parts, replacements, count, options) {
     var result = [].concat(parts)
     var len = parts.length
     for (var i = 1; i < len; i += 2) {
@@ -48,17 +49,18 @@
         if (part === 'n' && count != null) {
           val = count
         } else {
-          debug && console.warn('No "' + part + '" in placeholder object:', replacements)
+          options.debug && console.warn('No "' + part + '" in placeholder object:', replacements)
           val = '{' + part + '}'
         }
       }
       result[i] = val
     }
-    return result
+    return options.array ? result : result.join('')
   }
 
   var translatejs = function (messageObject, options) {
-    var debug = options && options.debug
+    options = options || {}
+    var debug = options.debug
 
     function getPluralValue (translation, count) {
       // Opinionated assumption: Pluralization rules are the same for negative and positive values.
@@ -99,11 +101,11 @@
         result = parts.length > 1 ? parts : parts[0]
         replCache[translation] = result
       }
-      result = result.pop ? assemble(result, replacements, count, debug) : result
+      result = result.pop ? assemble(result, replacements, count, tFunc.opts) : result
       return result
     }
 
-    function runTranslation (joinResult, translationKey, count, replacements) {
+    var tFunc = function (translationKey, count, replacements) {
       var translation = tFunc.keys[translationKey]
       var complex = count != null || replacements != null
 
@@ -131,17 +133,21 @@
       } else if (complex || debug) {
         translation = replacePlaceholders(translation, replacements, count)
       }
-
-      if (joinResult && translation && translation.join) {
-        return translation.join('')
-      }
       return translation
     }
 
-    var tFunc = runTranslation.bind(null, true)
-    tFunc.arr = runTranslation.bind(null, false)
+    // Convenience function.
+    tFunc.arr = function () {
+        var opts = tFunc.opts
+        var normalArrayOption = opts.array
+        opts.array = true
+        var result = tFunc.apply(null, arguments)
+        opts.array = normalArrayOption
+        return result
+      };
+
     tFunc.keys = messageObject || {}
-    tFunc.opts = options || {}
+    tFunc.opts = options
 
     return tFunc
   }

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@
     return obj && typeof obj === 'object'
   }
 
-  function assemble (parts, replacements, count, options) {
-    var result = [].concat(parts)
+  function assemble (parts, replacements, count, debug, array) {
+    var result = array ? [parts[0]] : parts[0]
     var len = parts.length
     for (var i = 1; i < len; i += 2) {
       var part = parts[i]
@@ -49,13 +49,18 @@
         if (part === 'n' && count != null) {
           val = count
         } else {
-          options.debug && console.warn('No "' + part + '" in placeholder object:', replacements)
+          debug && console.warn('No "' + part + '" in placeholder object:', replacements)
           val = '{' + part + '}'
         }
       }
-      result[i] = val
+      if ( array ) {
+        result[i] = val
+        result[i+1] = parts[i+1]
+      } else {
+        result += val + parts[i+1]
+      }
     }
-    return options.array ? result : result.join('')
+    return result
   }
 
   var translatejs = function (messageObject, options) {
@@ -101,7 +106,7 @@
         result = parts.length > 1 ? parts : parts[0]
         replCache[translation] = result
       }
-      result = result.pop ? assemble(result, replacements, count, tFunc.opts) : result
+      result = result.pop ? assemble(result, replacements, count, debug, tFunc.opts.array) : result
       return result
     }
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@
     return obj && typeof obj === 'object'
   }
 
-  function assemble (parts, replacements, count, debug, array) {
-    var result = array ? [parts[0]] : parts[0]
+  function assemble (parts, replacements, count, debug, asArray) {
+    var result = asArray ? [parts[0]] : parts[0]
     var len = parts.length
     for (var i = 1; i < len; i += 2) {
       var part = parts[i]
@@ -53,7 +53,7 @@
           val = '{' + part + '}'
         }
       }
-      if ( array ) {
+      if ( asArray ) {
         result[i] = val
         result[i+1] = parts[i+1]
       } else {

--- a/test.js
+++ b/test.js
@@ -266,4 +266,10 @@ describe('Return array option', function () {
     })
     expect(t.arr('test', { xyz: { foo: 'bar' } })).to.eql(['abc ', { foo: 'bar' }, ' def'])
   })
+  it('should return replacement-token translations as Arrays, when `array` option is supplied', function () {
+    var t = translate({
+      test: 'abc {xyz} def'
+    }, { array:true })
+    expect(t('test', { xyz: { foo: 'bar' } })).to.eql(['abc ', { foo: 'bar' }, ' def'])
+  })
 })


### PR DESCRIPTION
(Adds to #21)

Add `array` option and move "joinResult" check into `assemble`

This adds a bit more flexibility and reduces overhead for the large majority of translations where no replacements are performed.

Removing the `.bind()` overhead from the default function probably doesn't hurt either.