### PR TITLE
Support dynamic subkeys

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,20 +109,23 @@
       return result
     }
 
-    var tFunc = function (translationKey, count, replacements) {
+    var tFunc = function (translationKey, arg1, arg2) {
       var translation = tFunc.keys[translationKey]
-      var complex = count != null || replacements != null
+      var complex = arg1 != null || arg2 != null
+      var count, replacements, subkey
 
       if (complex) {
-        if (isObject(count)) {
-          var tmp = replacements
-          replacements = count
-          count = tmp
-        }
+        count = isObject(arg1) ? arg2 : arg1
+        replacements = isObject(arg1) ? arg1 : arg2
+        subkey = typeof count === 'string' && count
+        count = typeof count === 'number' && count
         replacements = replacements || {}
-        count = typeof count === 'number' ? count : null
 
-        if (count !== null && isObject(translation)) {
+        if (subkey && isObject(translation)) {
+          translation = translation[subkey]
+        }
+
+        if (count !== false && isObject(translation)) {
           // get appropriate plural translation string
           translation = getPluralValue(translation, count)
         }
@@ -131,8 +134,13 @@
       if (typeof translation !== 'string') {
         translation = translationKey
         if (debug) {
-          translation = '@@' + translation + '@@'
-          console.warn('Translation for "' + translationKey + '" not found.')
+          if (subkey) {
+            translation = '@@' + translationKey + '.' + subkey + '@@'
+            console.warn(['Translation for ', translationKey, ' with subkey ', subkey, ' not found.'].join('"'))
+          } else {
+            translation = '@@' + translation + '@@'
+            console.warn('Translation for "' + translationKey + '" not found.')
+          }
         }
       } else if (complex || debug) {
         translation = replacePlaceholders(translation, replacements, count)

--- a/test.js
+++ b/test.js
@@ -42,7 +42,8 @@ describe('translate.js', function () {
 
     'Prosa Key': 'This is prosa!',
 
-    'comboCounter': '{name} is {n} years old.'
+    comboCounter: '{name} is {n} years old.',
+    translationWithSubkeys: { 'foo': 'FOO' }
   }
 
   var t = translate(translationsObject)
@@ -69,6 +70,11 @@ describe('translate.js', function () {
 
   it('should return a translated string and replace a count', function () {
     expect(t('simpleCounter', 25)).to.equal('The count is 25.')
+  })
+
+  it('should return a translated string according to a potential dynamic subkey', function () {
+    var dynamicSubKey = 'foo';
+    expect(t('translationWithSubkeys', dynamicSubKey)).to.equal('FOO')
   })
 
   it('should return a translated string with the correct plural form (0)', function () {
@@ -171,6 +177,10 @@ describe('translate.js', function () {
   it('should return @@translationKey@@ if no translation is found and debug is true', function () {
     expect(t5('nonexistentkey')).to.equal('@@nonexistentkey@@')
   })
+  it('should return a translated string according to a potential dynamic subkey', function () {
+    expect(t5('translationWithSubkeys', 'not there')).to.equal('@@translationWithSubkeys.not there@@')
+  })
+
 
   var t6Keys = {
     fruit: '{0} apples, {1} oranges, {2} kiwis',


### PR DESCRIPTION
@maranomynet what do you think of this?

use case was that I sometimes have translations like `t('foo.' + bar)` where bar is a string (e. G. a state of a think). This is hard to statically analyse (e. G. to kick unused translations).

PR would solve this by allowing `t('foo', bar)` in this case given that the translation looks like
```
foo: {
  bar: 'this is it',
  baz: 'this not'
}
```