### PR TITLE
Support dynamic subkeys – alternative approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ First create a language specific object for your translations:
 var messages = {
     like: 'I like this.',
     likeThing: 'I like {thing}!',
-    like01: 'I like {0} and {1}!',
+    likeTwoThings: 'I like {0} and {1}!',
     simpleCounter: 'The count is {n}.',
     hits: {
         0: 'No Hits',
         1: '{n} Hit',
         2: '{n} Hitse',  //some slavic langs have multiple plural forms
         3: '{n} Hitses', //some slavic langs have multiple plural forms
-        n: '{n} Hits' // default
+        n: '{n} Hits', // default
     },
     date: {
         1: '{day}. January {year}',
@@ -74,7 +74,7 @@ var messages = {
         9: '{day}. September {year}',
         10: '{day}. October {year}',
         11: '{day}. November {year}',
-        12: '{day}. December {year}'
+        12: '{day}. December {year}',
     },
 
     'Prosa Key': 'This is prosa!',  
@@ -97,7 +97,7 @@ t('Prosa Key') => 'This is prosa!'
 //placeholders - named
 t('likeThing', {thing: 'the Sun'}) => 'I like the Sun!'
 //placeholders - array
-t('like01', ['Alice', 'Bob']) => 'I like Alice and Bob!'
+t('likeTwoThings', ['Alice', 'Bob']) => 'I like Alice and Bob!'
 
 //count
 t('simpleCounter', 25) => 'The count is 25'
@@ -113,9 +113,11 @@ t('date', 2, {day: '13', year: 2014}) => '13. February 2014'
 It is flexible, so you can add/replace translations after the fact by modifying the `.keys` property, like so:
 
 ```js
+//add/update keys
 t.keys['add-key'] = 'Sorry I am late!'
 t('add-key'); => 'Sorry I am late!'
 
+//replace keys object
 t.keys = { 'new-key': 'All is new!' }
 t('new-key'); => 'All is new!'
 t('add-key'); => 'add-key' (No longer translated)
@@ -129,17 +131,17 @@ var t2 = function () { return t.apply(null,arguments); }
 ```
 
 
-### Custom pluralization
+### Pluralization
 
-You can also do customized pluralization like this:
+You can also do customized pluralization selection, like this:
 
 ```js
 var messages_IS = {
     sheep: {
         0: 'Engar kindur',
-        13: 'Baaahd luck!'
         s: '{n} kind',
-        p: '{n} kindur'
+        p: '{n} kindur',
+        13: 'Baaahd luck!',
     }
 }
 var pluralize_IS = function ( n, tarnslationKey ) {
@@ -148,11 +150,11 @@ var pluralize_IS = function ( n, tarnslationKey ) {
 }
 var t = translate( messages_IS, { pluralize: pluralize_IS })
 
-t('sheep', 0) => 'Engar kindur'
-t('sheep', 1) => '1 kind'
-t('sheep', 2) => '2 kindur'
-t('sheep', 21) => '21 kind'
-t('sheep', 13) => 'Baaahd luck'  // explicit translation takes precedence 
+t('sheep', 0) => 'Engar kindur' // direct subkey hit takes precedence
+t('sheep', 1) => '1 kind'  // pluralize_IS(1) => 's' 
+t('sheep', 2) => '2 kindur'  // pluralize_IS(2) => 'p' 
+t('sheep', 21) => '21 kind'  // pluralize_IS(21) => 's'
+t('sheep', 13) => 'Baaahd luck'  // direct subkey match 
 ```
 
 Translate.js comes with a predefined `pluralize` functions for [several languages](pluralize/). These can be required into your code as needed, like so:
@@ -164,10 +166,10 @@ var t = translate( messages_IS, { pluralize:pluralize_IS  })
 
 Here's a large list of [pluralization algorithms by language](http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html?id=l10n/pluralforms).
 
-## Working with VDOM libs
 
-If you work with VDOM-libs such as [mithril.js](http://mithril.js.org/) you
-sometimes want to include VDOM nodes into the translation. This is possible
+## Working with VDOM libraries
+
+If you work with VDOM-libraries such as [mithril.js](http://mithril.js.org/) you sometimes want to include VDOM nodes into the translation. This is possible
 by using the `arr`-helper. It does not convert the translation result to a
 string but rather returns an array with all the placeholder-replacements left intact.
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ var options = {
 var t = translate(messages, [options])
 
 t('translationKey')
-t('translationKey', count)
+t('translationKey', subkey)
 t('translationKey', {replaceKey: 'replacevalue'})
-t('translationKey', count, {replaceKey: 'replacevalue'})
-t('translationKey', {replaceKey: 'replacevalue'}, count)
+t('translationKey', subkey, {replaceKey: 'replacevalue'})
+t('translationKey', {replaceKey: 'replacevalue'}, subkey)
 
 ```
 
@@ -76,6 +76,10 @@ var messages = {
         11: '{day}. November {year}',
         12: '{day}. December {year}',
     },
+    saveButton: {
+        label: 'Save',
+        tooltip: 'Save unsaved changes',
+    },
 
     'Prosa Key': 'This is prosa!',  
 
@@ -99,14 +103,18 @@ t('likeThing', {thing: 'the Sun'}) => 'I like the Sun!'
 //placeholders - array
 t('likeTwoThings', ['Alice', 'Bob']) => 'I like Alice and Bob!'
 
-//count
+//subkeys
+t('saveButton', 'label') => 'Save'
+t('saveButton', 'tooltip') => 'Save unsaved changes'
+
+//numerical subkeys (count)
 t('simpleCounter', 25) => 'The count is 25'
 t('hits', 0) => 'No Hits'
 t('hits', 1) => '1 Hit'
 t('hits', 3) => '3 Hitses'
 t('hits', 99) => '99 Hits'
 
-//combined count and placeholders
+//combined count/subkey and placeholders
 t('date', 2, {day: '13', year: 2014}) => '13. February 2014'
 ```
 
@@ -149,12 +157,17 @@ var pluralize_IS = function ( n, tarnslationKey ) {
     return (n%10 !== 1 || n%100 === 11) ? 'p' : 's'
 }
 var t = translate( messages_IS, { pluralize: pluralize_IS })
+```
 
+With this setup, all failed numerical subkey lookups get passed through the pluralization function and the return value (in this case either 's' or 'p')
+is then used as a subkey, like so.
+
+```js
 t('sheep', 0) => 'Engar kindur' // direct subkey hit takes precedence
 t('sheep', 1) => '1 kind'  // pluralize_IS(1) => 's' 
 t('sheep', 2) => '2 kindur'  // pluralize_IS(2) => 'p' 
 t('sheep', 21) => '21 kind'  // pluralize_IS(21) => 's'
-t('sheep', 13) => 'Baaahd luck'  // direct subkey match 
+t('sheep', 13) => 'Baaahd luck'  // direct subkey hit 
 ```
 
 Translate.js comes with a predefined `pluralize` functions for [several languages](pluralize/). These can be required into your code as needed, like so:

--- a/index.js
+++ b/index.js
@@ -71,9 +71,6 @@
       // By normalizing all values to positive, pluralization functions become simpler, and less error-prone by accident.
       var mappedCount = Math.abs(count)
 
-      if (translation[mappedCount] != null) {
-        return translation[mappedCount]
-      }
       var plFunc = (tFunc.opts || {}).pluralize
       mappedCount = plFunc ? plFunc(mappedCount, translation) : mappedCount
       if (translation[mappedCount] != null) {
@@ -120,19 +117,29 @@
           count = tmp
         }
         replacements = replacements || {}
-        count = typeof count === 'number' ? count : null
 
         if (count !== null && isObject(translation)) {
-          // get appropriate plural translation string
-          translation = getPluralValue(translation, count)
+          var propValue = translation[count]
+          if (propValue != null) {
+            translation = propValue
+          }
+          else if (typeof count === 'number') {
+            // get appropriate plural translation string
+            translation = getPluralValue(translation, count)
+          }
         }
       }
 
       if (typeof translation !== 'string') {
         translation = translationKey
         if (debug) {
-          translation = '@@' + translation + '@@'
-          console.warn('Translation for "' + translationKey + '" not found.')
+          if (count && typeof count === 'string') {
+            translation = '@@' + translationKey + '.' + count + '@@'
+            console.warn(['Translation for ', translationKey, ' with subkey ', count, ' not found.'].join('"'))
+          } else {
+            translation = '@@' + translation + '@@'
+            console.warn('Translation for "' + translationKey + '" not found.')
+          }
         }
       } else if (complex || debug) {
         translation = replacePlaceholders(translation, replacements, count)

--- a/index.js
+++ b/index.js
@@ -106,26 +106,26 @@
       return result
     }
 
-    var tFunc = function (translationKey, count, replacements) {
+    var tFunc = function (translationKey, subKey, replacements) {
       var translation = tFunc.keys[translationKey]
-      var complex = count != null || replacements != null
+      var complex = subKey != null || replacements != null
 
       if (complex) {
-        if (isObject(count)) {
+        if (isObject(subKey)) {
           var tmp = replacements
-          replacements = count
-          count = tmp
+          replacements = subKey
+          subKey = tmp
         }
         replacements = replacements || {}
 
-        if (count !== null && isObject(translation)) {
-          var propValue = translation[count]
+        if (subKey !== null && isObject(translation)) {
+          var propValue = translation[subKey]
           if (propValue != null) {
             translation = propValue
           }
-          else if (typeof count === 'number') {
+          else if (typeof subKey === 'number') {
             // get appropriate plural translation string
-            translation = getPluralValue(translation, count)
+            translation = getPluralValue(translation, subKey)
           }
         }
       }
@@ -133,16 +133,16 @@
       if (typeof translation !== 'string') {
         translation = translationKey
         if (debug) {
-          if (count && typeof count === 'string') {
-            translation = '@@' + translationKey + '.' + count + '@@'
-            console.warn(['Translation for ', translationKey, ' with subkey ', count, ' not found.'].join('"'))
+          if (subKey && typeof subKey === 'string') {
+            translation = '@@' + translationKey + '.' + subKey + '@@'
+            console.warn(['Translation for ', translationKey, ' with subkey ', subKey, ' not found.'].join('"'))
           } else {
             translation = '@@' + translation + '@@'
             console.warn('Translation for "' + translationKey + '" not found.')
           }
         }
       } else if (complex || debug) {
-        translation = replacePlaceholders(translation, replacements, count)
+        translation = replacePlaceholders(translation, replacements, subKey)
       }
       return translation
     }

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@
       if (translation.n != null) {
         return translation.n
       }
-      debug && console.warn('No plural forms found for "' + count + '" in', translation)
     }
 
     var replCache = {}
@@ -133,9 +132,9 @@
       if (typeof translation !== 'string') {
         translation = translationKey
         if (debug) {
-          if (subKey && typeof subKey === 'string') {
+          if (subKey != null) {
             translation = '@@' + translationKey + '.' + subKey + '@@'
-            console.warn(['Translation for ', translationKey, ' with subkey ', subKey, ' not found.'].join('"'))
+            console.warn('No translation or pluralization form found for "' + subKey + '" in' + translationKey)
           } else {
             translation = '@@' + translation + '@@'
             console.warn('Translation for "' + translationKey + '" not found.')

--- a/test.js
+++ b/test.js
@@ -42,7 +42,8 @@ describe('translate.js', function () {
 
     'Prosa Key': 'This is prosa!',
 
-    'comboCounter': '{name} is {n} years old.'
+    comboCounter: '{name} is {n} years old.',
+    translationWithSubkeys: { 'foo': 'FOO' }
   }
 
   var t = translate(translationsObject)
@@ -69,6 +70,11 @@ describe('translate.js', function () {
 
   it('should return a translated string and replace a count', function () {
     expect(t('simpleCounter', 25)).to.equal('The count is 25.')
+  })
+
+  it('should return a translated string according to a potential dynamic subkey', function () {
+    var dynamicSubKey = 'foo';
+    expect(t('translationWithSubkeys', dynamicSubKey)).to.equal('FOO')
   })
 
   it('should return a translated string with the correct plural form (0)', function () {
@@ -168,9 +174,11 @@ describe('translate.js', function () {
 
   // debug enabled
   var t5 = translate(translationsObject, {debug: true})
-  it('should return @@translationKey@@ if no translation is found and debug is true', function () {
+  it('should return @@translationKey@@/@@translationKey.subKey@@ if no translation is found and debug is true', function () {
     expect(t5('nonexistentkey')).to.equal('@@nonexistentkey@@')
+    expect(t5('translationWithSubkeys', 'not there')).to.equal('@@translationWithSubkeys.not there@@')
   })
+
 
   var t6Keys = {
     fruit: '{0} apples, {1} oranges, {2} kiwis',

--- a/test.js
+++ b/test.js
@@ -177,6 +177,8 @@ describe('translate.js', function () {
   it('should return @@translationKey@@/@@translationKey.subKey@@ if no translation is found and debug is true', function () {
     expect(t5('nonexistentkey')).to.equal('@@nonexistentkey@@')
     expect(t5('translationWithSubkeys', 'not there')).to.equal('@@translationWithSubkeys.not there@@')
+    expect(t5('translationWithSubkeys', 42)).to.equal('@@translationWithSubkeys.42@@')
+    expect(t5('nonexistentkey', 42)).to.equal('@@nonexistentkey.42@@')
   })
 
 


### PR DESCRIPTION
Supports the same functionality as #26 but with fewer type checks and `isObject()` lookups, and no repeated `count` lookup inside `getPluralValue`.

Also improves debug messages for numerical (i.e. `count`) subkeys and failed pluralizations, and combines `console.warn()` calls