### PR TITLE
Feature: default subKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var messages = {
         1: '{n} Hit',
         2: '{n} Hitse',  //some slavic langs have multiple plural forms
         3: '{n} Hitses', //some slavic langs have multiple plural forms
-        n: '{n} Hits', // default
+        n: '{n} Hits', // default for other numbers
     },
     date: {
         1: '{day}. January {year}',
@@ -80,6 +80,12 @@ var messages = {
     saveButton: {
         label: 'Save',
         tooltip: 'Save unsaved changes',
+    },
+    simpleButton: 'Simple',
+
+    hasDefaultSubkey: {
+        foo: 'Foo subkey value',
+        __: 'Default value',
     },
 
     'Prosa Key': 'This is prosa!',  
@@ -108,6 +114,16 @@ t('likeTwoThings', ['Alice', 'Bob']) => 'I like Alice and Bob!'
 //subkeys
 t('saveButton', 'label') => 'Save'
 t('saveButton', 'tooltip') => 'Save unsaved changes'
+
+//simple translations ignore subkeys
+t('simpleButton', 'label') => 'Simple'
+t('simpleButton', 'tooltip') => 'Simple'
+
+//default '__' subkey
+t('hasDefaultSubkey', 'foo') => 'Foo subkey value'
+t('hasDefaultSubkey', 'missing') => 'Default value'
+t('hasDefaultSubkey') => 'Default value'
+
 
 //numerical subkeys (count)
 t('simpleCounter', 25) => 'The count is 25'
@@ -141,6 +157,8 @@ var t2 = function () {
     return t.apply(null,arguments)
 }
 ```
+
+
 
 
 ### Pluralization

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ var messages = {
 
     hasDefaultSubkey: {
         foo: 'Foo subkey value',
-        __: 'Default value',
+        '*': 'Default value',
     },
 
     'Prosa Key': 'This is prosa!',  
@@ -119,7 +119,7 @@ t('saveButton', 'tooltip') => 'Save unsaved changes'
 t('simpleButton', 'label') => 'Simple'
 t('simpleButton', 'tooltip') => 'Simple'
 
-//default '__' subkey
+//default '*' subkey
 t('hasDefaultSubkey', 'foo') => 'Foo subkey value'
 t('hasDefaultSubkey', 'missing') => 'Default value'
 t('hasDefaultSubkey') => 'Default value'

--- a/index.js
+++ b/index.js
@@ -74,8 +74,9 @@ function translatejs(messageObject, options) {
 
   function tFunc(translationKey, subKey, replacements) {
     let translation = tFunc.keys[translationKey]
-    const translationIsObject = isObject(translation);
-    const complex = translationIsObject || subKey != null || replacements != null
+    const translationIsObject = isObject(translation)
+    const complex =
+      translationIsObject || subKey != null || replacements != null
 
     if (complex) {
       if (isObject(subKey)) {
@@ -86,7 +87,8 @@ function translatejs(messageObject, options) {
       replacements = replacements || {}
 
       if (translationIsObject) {
-        const propValue = (subKey != null && translation[subKey]) || translation['*']
+        const propValue =
+          (subKey != null && translation[subKey]) || translation['*']
         if (propValue != null) {
           translation = propValue
         } else if (typeof subKey === 'number') {

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ function translatejs(messageObject, options) {
 
   function tFunc(translationKey, subKey, replacements) {
     let translation = tFunc.keys[translationKey]
-    const complex = subKey != null || replacements != null
+    const translationIsObject = isObject(translation);
+    const complex = translationIsObject || subKey != null || replacements != null
 
     if (complex) {
       if (isObject(subKey)) {
@@ -84,8 +85,8 @@ function translatejs(messageObject, options) {
       }
       replacements = replacements || {}
 
-      if (subKey !== null && isObject(translation)) {
-        const propValue = translation[subKey]
+      if (translationIsObject) {
+        const propValue = (subKey != null && translation[subKey]) || translation.__
         if (propValue != null) {
           translation = propValue
         } else if (typeof subKey === 'number') {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function translatejs(messageObject, options) {
       replacements = replacements || {}
 
       if (translationIsObject) {
-        const propValue = (subKey != null && translation[subKey]) || translation.__
+        const propValue = (subKey != null && translation[subKey]) || translation['*']
         if (propValue != null) {
           translation = propValue
         } else if (typeof subKey === 'number') {

--- a/test.js
+++ b/test.js
@@ -38,12 +38,16 @@ describe('translate.js', function() {
       10: '{day}. October {year}',
       11: '{day}. November {year}',
       12: '{day}. December {year}',
+
+      __: 'WAT! {n}!?',
+      n: 'Is always overridden by __',
     },
 
     'Prosa Key': 'This is prosa!',
 
     comboCounter: '{name} is {n} years old.',
     translationWithSubkeys: { foo: 'FOO' },
+    translationWithDefaultSubkey: { __: 'I am a default value' },
   }
 
   var t = translate(translationsObject)
@@ -193,6 +197,14 @@ describe('translate.js', function() {
       'I like this.'
     )
   })
+  it('should return the "__" subkey value if no subkey is passed', function () {
+    expect(t3b('translationWithDefaultSubkey')).to.equal('I am a default value')
+  })
+  it('should retry the "__" subkey value if passed subkey is missing', function () {
+    expect(t3b('translationWithDefaultSubkey', 'nonexistentsubkey') ).to.equal('I am a default value')
+    expect(t3b('date', 13, {day: '13', year: 2013}) ).to.equal('WAT! 13!?')
+  })
+
 
   // wrong arguments
   var t4 = translate(translationsObject, 'asd')
@@ -310,6 +322,8 @@ describe('translate.js', function() {
   })
 })
 
+
+
 describe('Return array option', function() {
   it('should return replacement-token translations as Arrays, when t.arr() is called', function() {
     var t = translate({
@@ -345,6 +359,8 @@ describe('Return array option', function() {
     expect(t.arr('test3', 'subkey')).to.eql('simple')
   })
 })
+
+
 
 describe('alias usage', function() {
   it('should work with simple translations', function() {

--- a/test.js
+++ b/test.js
@@ -39,15 +39,15 @@ describe('translate.js', function() {
       11: '{day}. November {year}',
       12: '{day}. December {year}',
 
-      __: 'WAT! {n}!?',
-      n: 'Is always overridden by __',
+      '*': 'WAT! {n}!?',
+      n: 'Is always overridden by "*"',
     },
 
     'Prosa Key': 'This is prosa!',
 
     comboCounter: '{name} is {n} years old.',
     translationWithSubkeys: { foo: 'FOO' },
-    translationWithDefaultSubkey: { __: 'I am a default value' },
+    translationWithDefaultSubkey: { '*': 'I am a default value' },
   }
 
   var t = translate(translationsObject)
@@ -197,10 +197,10 @@ describe('translate.js', function() {
       'I like this.'
     )
   })
-  it('should return the "__" subkey value if no subkey is passed', function () {
+  it('should return the "*" subkey value if no subkey is passed', function () {
     expect(t3b('translationWithDefaultSubkey')).to.equal('I am a default value')
   })
-  it('should retry the "__" subkey value if passed subkey is missing', function () {
+  it('should retry the "*" subkey value if passed subkey is missing', function () {
     expect(t3b('translationWithDefaultSubkey', 'nonexistentsubkey') ).to.equal('I am a default value')
     expect(t3b('date', 13, {day: '13', year: 2013}) ).to.equal('WAT! 13!?')
   })

--- a/test.js
+++ b/test.js
@@ -197,14 +197,15 @@ describe('translate.js', function() {
       'I like this.'
     )
   })
-  it('should return the "*" subkey value if no subkey is passed', function () {
+  it('should return the "*" subkey value if no subkey is passed', function() {
     expect(t3b('translationWithDefaultSubkey')).to.equal('I am a default value')
   })
-  it('should retry the "*" subkey value if passed subkey is missing', function () {
-    expect(t3b('translationWithDefaultSubkey', 'nonexistentsubkey') ).to.equal('I am a default value')
-    expect(t3b('date', 13, {day: '13', year: 2013}) ).to.equal('WAT! 13!?')
+  it('should retry the "*" subkey value if passed subkey is missing', function() {
+    expect(t3b('translationWithDefaultSubkey', 'nonexistentsubkey')).to.equal(
+      'I am a default value'
+    )
+    expect(t3b('date', 13, { day: '13', year: 2013 })).to.equal('WAT! 13!?')
   })
-
 
   // wrong arguments
   var t4 = translate(translationsObject, 'asd')
@@ -322,8 +323,6 @@ describe('translate.js', function() {
   })
 })
 
-
-
 describe('Return array option', function() {
   it('should return replacement-token translations as Arrays, when t.arr() is called', function() {
     var t = translate({
@@ -359,8 +358,6 @@ describe('Return array option', function() {
     expect(t.arr('test3', 'subkey')).to.eql('simple')
   })
 })
-
-
 
 describe('alias usage', function() {
   it('should work with simple translations', function() {


### PR DESCRIPTION
I've found this to be very useful - since it allows incrementally upgrading plain translation strings to subkeyed objects, without requiring rewrite of existing code which may rely on the original simple translations.

It also allows less/looser normalization of translation objects, which leads to less need for pointless repetition/verbosity for users maintaining/editing translation files.

This closes the circle on the feature where subkeys are ignored for plain-text translations https://github.com/StephanHoyer/translate.js/commit/08c36f6

This change has slight impact on raw performance (`isObject` check for all translations), but the added power/flexibility far outweighs it IMO.

----

Given these translations:
```js
var langA = {
  saveButton: 'Save',
  cancelButton: {
    '*': 'Cancel',
    tooltip: 'Cancel all the things \ö/'
  }
}

var langB = {
  saveButton: {
    '*': 'Save all the things!!',
    label: 'Save',
  },
  cancelButton: 'Cancel'
}

var keys = Math.random() > .5 ? langA : langB
var t = translate(keys)
```

All of these work equally well:
```js
t('saveButton')
t('saveButton', 'label')
t('saveButton', 'tooltip')

t('cancelButton')
t('cancelButton', 'label')
t('cancelButton', 'tooltip')
```
