### PR TITLE
Allow replacements of placeholders for non-existing keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@
             console.warn('Translation for "' + translationKey + '" not found.')
           }
         }
-      } if (complex || debug) {
+      }
+
+      if (complex || debug) {
         translation = replacePlaceholders(translation, replacements, subKey)
       }
       return translation

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@
             console.warn('Translation for "' + translationKey + '" not found.')
           }
         }
-      } else if (complex || debug) {
+      } if (complex || debug) {
         translation = replacePlaceholders(translation, replacements, subKey)
       }
       return translation

--- a/test.js
+++ b/test.js
@@ -64,6 +64,10 @@ describe('translate.js', function () {
     expect(t('like', {thing: 'Sun'})).to.equal('I like Sun!')
   })
 
+  it('should return a not-translated string and replace a placeholder ', function () {
+    expect(t('This {thing} not translated, yet', {thing: 'string'})).to.equal('This string not translated, yet')
+  })
+
   it('should return a translated string and show missing placeholders', function () {
     expect(t('like')).to.equal('I like {thing}!')
   })


### PR DESCRIPTION
Removed an "else" statement to allow replacement of placeholders even when the key not found in the message object. We do not want to prepare messages object for base language, so I need to make placeholder replacement also work for missing keys.