### PR TITLE
fix: Transpile published CJS module to es5 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 
 
+## 1.1.1
+_2018-05-28_
+* fix: Publish CommonJS module in ES5 syntax ([#37](https://github.com/StephanHoyer/translate.js/pull/37))
+
+
+
 ## 1.1.0
 _2018-05-04_
 * feat: Support default/"wild-card" `*` subkeys as fallback for missing subkey translations ([#37](https://github.com/StephanHoyer/translate.js/pull/37))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translate.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Javascript micro library for translations (i18n) with support for placeholders and multiple plural forms.",
   "devDependencies": {
     "benchmark": "2.1.4",
@@ -8,11 +8,12 @@
     "mocha": "5.1.1",
     "onchange": "3.3.0",
     "prettier": "1.12.1",
-    "rollup": "0.58.2"
+    "rollup": "0.58.2",
+    "rollup-plugin-buble": "0.19.2"
   },
   "scripts": {
     "prepublish": "npm run build",
-    "build": "rollup --i index.js --o common.js -f cjs",
+    "build": "rollup -c",
     "_test": "node_modules/mocha/bin/mocha test.js",
     "test": "npm run format && npm run build && npm run _test",
     "format": "prettier *.js pluralize/*.js --write",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+import buble from 'rollup-plugin-buble'
+
+export default {
+  input: 'index.js',
+  plugins: [buble()],
+  output: {
+    file: 'common.js',
+    format: 'cjs',
+  },
+}


### PR DESCRIPTION
Closes #47